### PR TITLE
Updated instructions in README.md based on issues with filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,21 @@ Start SAP:
 
 Copy files into container:
 `docker cp .\sap_netweaver_as_abap_751_sp02_ase_dev_edition.part01.rar nwabap751:/tmp/`
+
+## Additional remarks when facing issues with file sizes
+
+If you are using Docker Community Edition on OS X10.x you could run in physical volume size limitations, especially when you are a more frequent Docker user.
+
+You can use docker-machine for creating a virtualbox (so you need virtualbox installed on your machine) which only purpose is to run the Docker engine on it. "docker-machine" is part of the local Docker engine installation - if you do not have this command available then please install Docker Toolbox (https://www.docker.com/products/docker-toolbox).
+
+In my example "Virtualbox" needs to be installed on the machine as a precondition as well (https://www.virtualbox.org/).
+
+Use this command to create a virtual machine where Docker engine will be spin up inside:
+
+`docker-machine create -d "virtualbox" --virtualbox-cpu-count "2" --virtualbox-disk-size "150000" --virtualbox-memory "6500" abap´
+
+after success execution you have now a virtual machine (this works also fine for AWS EC2, btw) with 150 GB disk space and 6.5 GB RAM. If you still run into issues you might have to change the file driver.
+
+Use `docker-machine ls`to find the available virtual machines. Use `docker-machine ip abap to find out the IP address of your virtual host.
+
+Follow the instructions on the screen to connect to it.

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ In my example "Virtualbox" needs to be installed on the machine as a preconditio
 
 Use this command to create a virtual machine where Docker engine will be spin up inside:
 
-`docker-machine create -d "virtualbox" --virtualbox-cpu-count "2" --virtualbox-disk-size "150000" --virtualbox-memory "6500" abap´
+`docker-machine create -d "virtualbox" --virtualbox-cpu-count "2" --virtualbox-disk-size "150000" --virtualbox-memory "6500" abap`
 
 after success execution you have now a virtual machine (this works also fine for AWS EC2, btw) with 150 GB disk space and 6.5 GB RAM. If you still run into issues you might have to change the file driver.
 
-Use `docker-machine ls`to find the available virtual machines. Use `docker-machine ip abap to find out the IP address of your virtual host.
+Use `docker-machine ls`to find the available virtual machines. Use `docker-machine ip abap` to find out the IP address of your virtual host.
 
 Follow the instructions on the screen to connect to it.


### PR DESCRIPTION
Hi Lars,
when working with Docker it appears on OS X that the file system size is set too low by default. OS X has some specialties regarding Docker so docker-machine is the way to go. On Windows this could also be a good alternative if someone doesn't want to "pollute" the installation on hostsystem.

Kind regards
Martin